### PR TITLE
LSX-Dodgers v1.34に対応

### DIFF
--- a/hdd.asm
+++ b/hdd.asm
@@ -475,6 +475,8 @@ HDRWC:
 	inc h		;memory addressを進める
 	inc h
 	inc de		;セクタ位置を進める
+	ld a,d
+	or e
 	jr	nc,HDLBANC
 	inc c
 HDLBANC:

--- a/hdd.asm
+++ b/hdd.asm
@@ -477,7 +477,7 @@ HDRWC:
 	inc de		;セクタ位置を進める
 	ld a,d
 	or e
-	jr	nc,HDLBANC
+	jr	nz,HDLBANC
 	inc c
 HDLBANC:
 	xor a


### PR DESCRIPTION
FAT16対応の為にDPBの仕様が変わったLSX-Dodgersに合わせて調整しました。
また、今後の32MBオーバーの為にWRITE CRUSTERとREAD CRUSTERの24ビット化をお願いします。
現在のDEレジスタでセクタ番号を指定している部分にCレジスタを加えてCDEの24ビットでアクセスと考えています。
LSX-Dodgers v1.34ではCレジスタを必ず「0」になるようにしていますので対応の方していただけましたら幸いです。